### PR TITLE
Switched to /shifts/exchange of 42ActivityAPI.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,6 @@
 	"name": "42CleaningShiftExchangeService",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
-	"postCreateCommand": "npm ci"
+	"postCreateCommand": "npm ci",
+	"runArgs": ["--network=docker-network"]
 }

--- a/.env_template
+++ b/.env_template
@@ -2,5 +2,4 @@ TOKEN="Discord-bot-token"
 CLIENT_ID="Discord-bot-client-ID"
 GUILD_ID="Discord-server-ID"
 REPORT_CHANNEL_ID="Discord-channel-ID"
-API_URL_FETCHSHIFTSOFDAY="url"
 API_URL_FT_ACTIVITY=http://api:4242

--- a/.env_template
+++ b/.env_template
@@ -1,0 +1,6 @@
+TOKEN="Discord-bot-token"
+CLIENT_ID="Discord-bot-client-ID"
+GUILD_ID="Discord-server-ID"
+REPORT_CHANNEL_ID="Discord-channel-ID"
+API_URL_FETCHSHIFTSOFDAY="url"
+API_URL_FT_ACTIVITY=http://api:4242

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@types/node-cron": "^3.0.11",
+        "axios": "^1.7.2",
         "discord.js": "^14.15.2",
         "dotenv": "^16.4.5",
         "fs": "^0.0.1-security",
+        "node-cron": "^3.0.3",
         "node-fetch": "^2.7.0",
         "path": "^0.12.7"
       },
@@ -503,8 +505,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -569,7 +580,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -630,7 +640,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -908,11 +917,29 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -1139,7 +1166,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1148,7 +1174,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -1179,6 +1204,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1301,6 +1337,11 @@
       "engines": {
         "node": ">= 0.6.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -1549,6 +1590,14 @@
         "inherits": "2.0.3"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1585,9 +1634,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "dependencies": {
     "@types/node-cron": "^3.0.11",
+    "axios": "^1.7.2",
     "discord.js": "^14.15.2",
     "dotenv": "^16.4.5",
     "fs": "^0.0.1-security",
+    "node-cron": "^3.0.3",
     "node-fetch": "^2.7.0",
     "path": "^0.12.7"
   },

--- a/src/commands/koukan/koukan.ts
+++ b/src/commands/koukan/koukan.ts
@@ -36,17 +36,21 @@ module.exports = {
         const partnerOriginalShiftDate = interaction.options.get('partner_original_shift_date');
         const partnerLogin = interaction.options.get('partner_login');
 
-        const endpoint = `https://script.google.com/macros/s/AKfycbzKa4NnOjH8xfptU0qJ1ee-M5bDvp5y5FKfedRQ3jh8NjOcHj3QAMBHkwdEM2QKzTblzw/exec/koukan?date1=${exchangeDate?.value}&name1=${originalCleanerLogin?.value}&date2=${partnerOriginalShiftDate?.value}&name2=${partnerLogin?.value}`;
-        const requestBody = {};
+        const apiurl = process.env.API_URL_FT_ACTIVITY + "/shifts/exchange";
+        const requestBody = {
+            "login1": originalCleanerLogin?.value,
+            "login2": partnerLogin?.value,
+            "date1": exchangeDate?.value,
+            "date2": partnerOriginalShiftDate?.value
+        };
 
         await interaction.deferReply();
         try {
-            const response = await fetch(endpoint, {
+            const response = await fetch(apiurl, {
                 method: 'POST',
                 body: JSON.stringify(requestBody),
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': 'Bearer ' + process.env.API_TOKEN
+                    'Content-Type': 'application/json'
                 }
             });
             if (!response.ok) {
@@ -57,11 +61,10 @@ module.exports = {
             
             const responseData = await response.json();
             console.log(responseData)
-
             
             const embed = new EmbedBuilder()
             .setTitle('掃除シフト交換成功')
-            .setDescription(`元の掃除担当者: ${originalCleanerLogin?.value}\n交換希望日程: ${exchangeDate?.value}\n交換相手の元の掃除シフト日程: ${partnerOriginalShiftDate?.value}\n交換相手: ${partnerLogin?.value}`);
+            .setDescription(`元の掃除担当者: ${originalCleanerLogin?.value}\n交換希望日程: ${exchangeDate?.value}\n交換相手: ${partnerLogin?.value}\n交換相手の元の掃除シフト日程: ${partnerOriginalShiftDate?.value}`);
             await interaction.editReply({ embeds: [embed] });
         } catch (error) {
             console.error(error);

--- a/src/repository/fetchShiftsOfDay.ts
+++ b/src/repository/fetchShiftsOfDay.ts
@@ -6,7 +6,7 @@ const endpoint = "/shift"
 
 export async function FetchShiftsOfDay(day: Date): Promise<ShiftList | void> {
 	const dateStr = DateToStr(day);
-	const url = `${process.env.API_URL}${endpoint}?date=${dateStr}`;
+	const url = `${process.env.API_URL_FETCHSHIFTSOFDAY}${endpoint}?date=${dateStr}`;
 	const response = await fetch(url, {
 		method: "GET",
 		headers: {

--- a/src/repository/fetchShiftsOfDay.ts
+++ b/src/repository/fetchShiftsOfDay.ts
@@ -2,11 +2,9 @@ import { ShiftList } from "../types/shift";
 import { ErrorMessage } from "../types/error-message";
 import { DateToStr } from "../utils/date-to-str";
 
-const endpoint = "/shift"
-
 export async function FetchShiftsOfDay(day: Date): Promise<ShiftList | void> {
 	const dateStr = DateToStr(day);
-	const url = `${process.env.API_URL_FETCHSHIFTSOFDAY}${endpoint}?date=${dateStr}`;
+	const url = `${process.env.API_URL_FT_ACTIVITY}/shifts?date=${dateStr}`;
 	const response = await fetch(url, {
 		method: "GET",
 		headers: {


### PR DESCRIPTION
This PR is to resolve #3.

- GASを利用したシフト交換方法から、42ActivityAPIを用いた方法へ切り替えを行った。
- Discordへの成功時の通知の順序を入れ替えた。
- HTTPステータスが400のときはInvalid input、500のときはInternal server error、それ以外のときはUnknown errorをエラー原因として表示するようにした。
```
// 例
exchangeTest アプリ 今日 15:41
掃除シフト交換に失敗しました。
原因: Invalid input.
```