### PR TITLE
Adding an Authorization Header

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -3,3 +3,4 @@ CLIENT_ID="Discord-bot-client-ID"
 GUILD_ID="Discord-server-ID"
 REPORT_CHANNEL_ID="Discord-channel-ID"
 API_URL_FT_ACTIVITY=http://api:4242
+API_KEY_FT_ACTIVITY="APIKEY"

--- a/src/commands/koukan/koukan.ts
+++ b/src/commands/koukan/koukan.ts
@@ -44,13 +44,16 @@ module.exports = {
             "date2": partnerOriginalShiftDate?.value
         };
 
+        const api_key = process.env.API_KEY_FT_ACTIVITY;
+
         await interaction.deferReply();
         try {
             const response = await fetch(apiurl, {
                 method: 'POST',
                 body: JSON.stringify(requestBody),
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer ' + api_key
                 }
             });
             if (!response.ok) {
@@ -60,6 +63,8 @@ module.exports = {
                     throw new Error('Invalid input.');
                 } else if (response.status === 500) {
                     throw new Error('Internal server error.');
+                } else if (response.status === 401) {
+                    throw new Error('Unauthorized.');
                 } else {
                     throw new Error('Unknown error.');
                 }

--- a/src/repository/fetchShiftsOfDay.ts
+++ b/src/repository/fetchShiftsOfDay.ts
@@ -5,10 +5,12 @@ import { DateToStr } from "../utils/date-to-str";
 export async function FetchShiftsOfDay(day: Date): Promise<ShiftList | void> {
 	const dateStr = DateToStr(day);
 	const url = `${process.env.API_URL_FT_ACTIVITY}/shifts?date=${dateStr}`;
+	const api_key = process.env.API_KEY_FT_ACTIVITY;
 	const response = await fetch(url, {
 		method: "GET",
 		headers: {
 			"Content-Type": "application/json",
+			"Authorization": `Bearer ${api_key}`,
 		},
 	});
 	if (!response.ok) {


### PR DESCRIPTION
This PR is to resolve #5

- .envを参照してAPIキーを取得し、AuthorizationヘッダにAPIキーを入れて送信させるように変更
- APIキーの検証に通過せず、401 Unauthorizedが返却された場合のエラー分岐の追加

> [!IMPORTANT]
> APIキーによる認証機能を有効化する場合、[42ActivityAPI](https://github.com/42association/42ActivityAPI/pull/80)の機能が必須です。しかし、この機能追加を行うと、42ActivityAPIを使用した他のプログラムに影響を与えます。